### PR TITLE
SARAALERT-1276: Support Continuous Exposure

### DIFF
--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -23,7 +23,9 @@ Description: "Sara Alert outputs additional extensions on Patient resources"
   date-of-arrival named date-of-arrival 0..1 MS and
   exposure-notes named exposure-notes 0..1 MS and
   travel-related-notes named travel-related-notes 0..1 MS and
-  additional-planned-travel-notes named additional-planned-travel-notes 0..1 MS
+  additional-planned-travel-notes named additional-planned-travel-notes 0..1 MS and
+  continuous-exposure named continuous-exposure 0..1 MS
+* obeys sara-1
 * telecom.extension contains phone-type named phone-type 0..1 MS
 * active MS
 * name MS
@@ -179,3 +181,16 @@ Id: address-type
 Title: "Address Type"
 Description: "Indicates if a monitoree's address is within the USA, or outside of the USA (options are: `USA` and `Foreign`). The extension only has meaning when used on the 'Patient.address' element. If this extension is not present the address is assumed to be within the USA."
 * value[x] only string
+
+// Continuous Exposure
+Extension: ContinuousExposure
+Id: continuous-exposure
+Title: "Continuous Exposure"
+Description: "Indicates if a monitoree's exposure to one or more cases is ongoing. This type of exposure means there is no known 'Last Date of Exposure'"
+* value[x] only boolean
+
+// Invariant for Continuous Exposure
+Invariant:  sara-1
+Description: "If 'Continuous Exposure' is set to true, then there shall be no 'Last Date of Exposure'"
+Expression: "extension.where(url='http://saraalert.org/StructureDefinition/continuous-exposure').first().valueBoolean implies Patient.extension.where(url='http://saraalert.org/StructureDefinition/last-date-of-exposure').first().valueDate.empty()"
+Severity:   #error

--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -26,6 +26,7 @@ Description: "Sara Alert outputs additional extensions on Patient resources"
   additional-planned-travel-notes named additional-planned-travel-notes 0..1 MS and
   continuous-exposure named continuous-exposure 0..1 MS
 * obeys sara-1
+* obeys sara-2
 * telecom.extension contains phone-type named phone-type 0..1 MS
 * active MS
 * name MS
@@ -193,4 +194,10 @@ Description: "Indicates if a monitoree's exposure to one or more cases is ongoin
 Invariant:  sara-1
 Description: "If 'Continuous Exposure' is set to true, then there shall be no 'Last Date of Exposure'"
 Expression: "extension.where(url='http://saraalert.org/StructureDefinition/continuous-exposure').first().valueBoolean implies Patient.extension.where(url='http://saraalert.org/StructureDefinition/last-date-of-exposure').first().valueDate.empty()"
+Severity:   #error
+
+// Invariant for Last Date of Exposure
+Invariant:  sara-2
+Description: "If 'Continuous Exposure' and 'Isolation' are both set to false, then there shall be a 'Last Date of Exposure'"
+Expression: "extension.where(url='http://saraalert.org/StructureDefinition/continuous-exposure').first().valueBoolean.not() and extension.where(url='http://saraalert.org/StructureDefinition/isolation').first().valueBoolean.not() implies Patient.extension.where(url='http://saraalert.org/StructureDefinition/last-date-of-exposure').first().valueDate.exists()"
 Severity:   #error


### PR DESCRIPTION
This adds a `continuous-exposure` extension so that we can support "Continuous Exposure" in the API. Additionally, this PR adds an invariant and applies it to the Sara Patient. The invariant indicates that Continuous Exposure being true implies that Last Date of Exposure should not be set.