### PR TITLE
SARAALERT-521: Write labs in API

### DIFF
--- a/input/fsh/observation.fsh
+++ b/input/fsh/observation.fsh
@@ -15,14 +15,11 @@ Description: "The Sara Alert Observation profile represents a monitoree lab resu
 * subject only Reference(SaraAlertPatient)
 * effective[x] only dateTime
 * effectiveDateTime MS
+* issued MS
+* issued ^comment = """
+    This value must be specified in the format YYYY-MM-DDThh:mm:ss.sss+zz:zz, but note that only
+    YYYY-MM-DD will be used by the system. The remainder will be ignored.
+    """
 * value[x] only CodeableConcept
 * valueCodeableConcept MS
 * valueCodeableConcept from SaraAlertLabResult (required)
-* extension contains report-date named report-date 0..1 MS
-
-// Preferred Contact Method Extension
-Extension: ReportDate
-Id: report-date
-Title: "Report Date"
-Description: "Represents the report date for a lab result."
-* value[x] only date

--- a/input/fsh/observation.fsh
+++ b/input/fsh/observation.fsh
@@ -5,10 +5,24 @@ Id: sara-alert-observation
 Title: "Sara Alert Observation Profile"
 Description: "The Sara Alert Observation profile represents a monitoree lab result."
 * meta.lastUpdated 1..1 MS
-* status 1..1 MS
-* subject only Reference(SaraAlertPatient)
+* status MS
+* status = #final
+* category 1..1 MS
+* category = CAT#laboratory
+* code 1..1 MS
+* code from SaraAlertLabType
 * subject 1..1 MS
+* subject only Reference(SaraAlertPatient)
 * effective[x] only dateTime
-* effectiveDateTime 1..1 MS
-* value[x] only string
-* valueString 1..1 MS
+* effectiveDateTime MS
+* value[x] only CodeableConcept
+* valueCodeableConcept MS
+* valueCodeableConcept from SaraAlertLabResult (required)
+* extension contains report-date named report-date 0..1 MS
+
+// Preferred Contact Method Extension
+Extension: ReportDate
+Id: report-date
+Title: "Report Date"
+Description: "Represents the report date for a lab result."
+* value[x] only date

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -1,4 +1,24 @@
 Alias: BCP47 = urn:ietf:bcp:47
+Alias: LNC = http://loinc.org
+Alias: SNO = http://snomed.info/sct
+Alias: NULL = http://terminology.hl7.org/CodeSystem/v3-NullFlavor
+Alias: CAT = http://terminology.hl7.org/CodeSystem/observation-category
+
+ValueSet: SaraAlertLabResult
+* SNO#10828004
+* SNO#260385009
+* SNO#82334004
+* NULL#oth
+
+ValueSet: SaraAlertLabType
+* LNC#94500-6
+* LNC#94558-4
+* LNC#94762-2
+* LNC#94563-4
+* LNC#94564-2
+* LNC#94562-6
+* NULL#oth
+* NULL#unk
 
 ValueSet: SaraAlertLanguage
 Title: "Sara Alert Language ValueSet"

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -8,7 +8,7 @@ ValueSet: SaraAlertLabResult
 * SNO#10828004
 * SNO#260385009
 * SNO#82334004
-* NULL#oth
+* NULL#OTH
 
 ValueSet: SaraAlertLabType
 * LNC#94500-6
@@ -17,8 +17,8 @@ ValueSet: SaraAlertLabType
 * LNC#94563-4
 * LNC#94564-2
 * LNC#94562-6
-* NULL#oth
-* NULL#unk
+* NULL#OTH
+* NULL#UNK
 
 ValueSet: SaraAlertLanguage
 Title: "Sara Alert Language ValueSet"


### PR DESCRIPTION
This adds documentation for the `SaraAlertObservation` profile to be up to date with SaraAlert/870, white adds support for writing lab results. In the process of adding support for that, the `SaraAlertObservation` profile had to change a bit. The main changes are listed below:

- `status` is required to be `final`
- `category` fixed to a value
- `code` is required and must be from SaraAlertLabType ValueSet
- `valueString` changed to `valueCodeableConcept`
- `valueCodeableConcept` must be from `SaraAlertLabResult` ValueSet
- Add `report-date` extension